### PR TITLE
Description support variable

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,7 @@
     </engines>
     <platform name="ios">
       <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
-          <string>This app needs microphone access</string>
+          <string>$MICROPHONE_USAGE_DESCRIPTION</string>
       </config-file>
     </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,6 +9,7 @@
         <engine name="cordova" version=">=3.0.0"/>
     </engines>
     <platform name="ios">
+      <preference name="MICROPHONE_USAGE_DESCRIPTION" default=" " />
       <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
           <string>$MICROPHONE_USAGE_DESCRIPTION</string>
       </config-file>


### PR DESCRIPTION
usage like: `ionic plugin add https://github.com/supgeek-rod/cordova-plugin-ios-microphone-permissions.git --variable MICROPHONE_USAGE_DESCRIPTION="This app needs microphone access" --save`